### PR TITLE
Update jackson-databind to version 2.22.1 and simplify date handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,8 @@
 ## Configuration & Compatibility Notes
 
 - Java 21 is the target runtime (`maven.compiler.source`/`target` in `pom.xml`).
+- `LocalDateTime` is the supported type for update dates; do not reintroduce legacy `java.util.Date`/Android fallback
+  fields or converter paths unless a new compatibility requirement explicitly calls for it.
 - Dependencies are managed in `pom.xml`; prefer updating versions through existing Maven properties when available
   (for example `openfeign.version`) and keep `CHANGELOG.md` consistent with releases.
 - `.codex/` is local tooling state and is ignored by git; do not include it in release or source changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 7.0.0
+
+- Cambio rompedor: se elimina el soporte legacy de fechas de actualizacion basadas en `java.util.Date` para Android.
+  Las fechas de actualizacion se exponen y calculan unicamente como `LocalDateTime`.
+- Eliminados los accesores `getFechaActualizacionAndroid()` y `setFechaActualizacionAndroid(...)` de `Premio`,
+  `ResumenNavidad` y `ResumenNino`.
+- Simplificados los convertidores de premios y resumenes para usar directamente `LocalDateTime`, eliminando el fallback
+  interno que capturaba `NoClassDefFoundError`.
+- Cambio rompedor en `SorteoResponseConverterUtils`: los metodos de fecha ya no reciben `Consumer<Date>` y solo aceptan
+  el setter de `LocalDateTime`.
+- Actualizacion de mantenimiento: `jackson-databind` de `2.22.0` a `2.22.1`.
+- Ampliacion y ajuste de tests unitarios de `PremioConverter` y `SorteoResponseConverterUtils` para reflejar el nuevo
+  contrato sin fallback legacy.
+
 ## 6.0.12
 
 - Actualizacion de mantenimiento: OpenFeign de `13.12` a `13.13` y `central-publishing-maven-plugin` de `0.10.0` a

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <groupId>io.github.jcprieto</groupId>
     <artifactId>loteria-navidad</artifactId>
-    <version>6.0.12</version>
+    <version>7.0.0</version>
     <packaging>jar</packaging>
     <build>
         <testSourceDirectory>src/test/java/</testSourceDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.22.0</version>
+            <version>2.22.1</version>
         </dependency>
         <dependency>
             <groupId>io.github.openfeign</groupId>

--- a/src/main/java/io/github/jcprieto/lib/loteria/converter/PremioConverter.java
+++ b/src/main/java/io/github/jcprieto/lib/loteria/converter/PremioConverter.java
@@ -9,7 +9,6 @@ import java.math.RoundingMode;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.Calendar;
 
 public class PremioConverter {
 
@@ -51,18 +50,11 @@ public class PremioConverter {
     }
 
     private static void setFechaActualizacionFromTimestamp(long timestamp, Premio premio) {
-        try {
-            premio.setFechaActualizacion(LocalDateTime.ofInstant(Instant.ofEpochSecond(timestamp),
-                    MADRID_ZONE));
-        } catch (NoClassDefFoundError n) {
-            Calendar date = Calendar.getInstance();
-            date.setTimeInMillis(timestamp * 1000L);
-            premio.setFechaActualizacionAndroid(date.getTime());
-        }
+        premio.setFechaActualizacion(LocalDateTime.ofInstant(Instant.ofEpochSecond(timestamp),
+                MADRID_ZONE));
     }
 
     private static void setFechaActualizacionFromSorteo(String fechaSorteo, Premio premio) {
-        SorteoResponseConverterUtils.setFechaActualizacion(fechaSorteo, premio::setFechaActualizacion,
-                premio::setFechaActualizacionAndroid);
+        SorteoResponseConverterUtils.setFechaActualizacion(fechaSorteo, premio::setFechaActualizacion);
     }
 }

--- a/src/main/java/io/github/jcprieto/lib/loteria/converter/ResumenNavidadConverter.java
+++ b/src/main/java/io/github/jcprieto/lib/loteria/converter/ResumenNavidadConverter.java
@@ -73,8 +73,7 @@ public class ResumenNavidadConverter {
     private static void setFechaActualizacion(String fechaSorteo, ResumenNavidad resumen) {
         SorteoResponseConverterUtils.setFechaActualizacion(
                 fechaSorteo,
-                resumen::setFechaActualizacion,
-                resumen::setFechaActualizacionAndroid
+                resumen::setFechaActualizacion
         );
     }
 

--- a/src/main/java/io/github/jcprieto/lib/loteria/converter/ResumenNavidadConverter.java
+++ b/src/main/java/io/github/jcprieto/lib/loteria/converter/ResumenNavidadConverter.java
@@ -65,8 +65,7 @@ public class ResumenNavidadConverter {
     private static void setFechaActualizacion(Premios premios, ResumenNavidad resumen) {
         SorteoResponseConverterUtils.setFechaActualizacionFromTimestamp(
                 premios.getTimestamp(),
-                resumen::setFechaActualizacion,
-                resumen::setFechaActualizacionAndroid
+                resumen::setFechaActualizacion
         );
     }
 

--- a/src/main/java/io/github/jcprieto/lib/loteria/converter/ResumenNinoConverter.java
+++ b/src/main/java/io/github/jcprieto/lib/loteria/converter/ResumenNinoConverter.java
@@ -74,8 +74,7 @@ public class ResumenNinoConverter {
     private static void setFechaActualizacion(String fechaSorteo, ResumenNino resumen) {
         SorteoResponseConverterUtils.setFechaActualizacion(
                 fechaSorteo,
-                resumen::setFechaActualizacion,
-                resumen::setFechaActualizacionAndroid
+                resumen::setFechaActualizacion
         );
     }
 

--- a/src/main/java/io/github/jcprieto/lib/loteria/converter/ResumenNinoConverter.java
+++ b/src/main/java/io/github/jcprieto/lib/loteria/converter/ResumenNinoConverter.java
@@ -66,8 +66,7 @@ public class ResumenNinoConverter {
     private static void setFechaActualizacion(Premios premios, ResumenNino resumen) {
         SorteoResponseConverterUtils.setFechaActualizacionFromTimestamp(
                 premios.getTimestamp(),
-                resumen::setFechaActualizacion,
-                resumen::setFechaActualizacionAndroid
+                resumen::setFechaActualizacion
         );
     }
 

--- a/src/main/java/io/github/jcprieto/lib/loteria/converter/SorteoResponseConverterUtils.java
+++ b/src/main/java/io/github/jcprieto/lib/loteria/converter/SorteoResponseConverterUtils.java
@@ -8,7 +8,10 @@ import org.slf4j.LoggerFactory;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 public final class SorteoResponseConverterUtils {
@@ -90,15 +93,8 @@ public final class SorteoResponseConverterUtils {
         }
     }
 
-    public static void setFechaActualizacionFromTimestamp(long timestamp, Consumer<LocalDateTime> localSetter,
-                                                          Consumer<Date> dateSetter) {
-        try {
-            localSetter.accept(LocalDateTime.ofInstant(Instant.ofEpochSecond(timestamp), MADRID_ZONE));
-        } catch (NoClassDefFoundError n) {
-            Calendar date = Calendar.getInstance();
-            date.setTimeInMillis(timestamp * 1000L);
-            dateSetter.accept(date.getTime());
-        }
+    public static void setFechaActualizacionFromTimestamp(long timestamp, Consumer<LocalDateTime> localSetter) {
+        localSetter.accept(LocalDateTime.ofInstant(Instant.ofEpochSecond(timestamp), MADRID_ZONE));
     }
 
     private static boolean isNumeric(String value) {

--- a/src/main/java/io/github/jcprieto/lib/loteria/converter/SorteoResponseConverterUtils.java
+++ b/src/main/java/io/github/jcprieto/lib/loteria/converter/SorteoResponseConverterUtils.java
@@ -5,8 +5,6 @@ import io.github.jcprieto.lib.loteria.model.json.navidad.SorteoNavidadResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -81,20 +79,12 @@ public final class SorteoResponseConverterUtils {
         return resultado;
     }
 
-    public static void setFechaActualizacion(String fechaSorteo, Consumer<LocalDateTime> localSetter,
-                                             Consumer<Date> dateSetter) {
+    public static void setFechaActualizacion(String fechaSorteo, Consumer<LocalDateTime> localSetter) {
         if (fechaSorteo == null) {
             return;
         }
         try {
             localSetter.accept(LocalDateTime.parse(fechaSorteo.replace(' ', 'T')));
-        } catch (NoClassDefFoundError n) {
-            try {
-                Date date = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.ROOT).parse(fechaSorteo);
-                dateSetter.accept(date);
-            } catch (ParseException e) {
-                LOG.error("Formato de fecha no valido: {}", fechaSorteo, e);
-            }
         } catch (RuntimeException e) {
             LOG.error("Error al parsear fecha: {}", fechaSorteo, e);
         }

--- a/src/main/java/io/github/jcprieto/lib/loteria/model/Premio.java
+++ b/src/main/java/io/github/jcprieto/lib/loteria/model/Premio.java
@@ -4,13 +4,11 @@ import io.github.jcprieto.lib.loteria.enumeradores.EstadoSorteo;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.Date;
 
 public class Premio {
     private BigDecimal cantidad = BigDecimal.ZERO;
     private LocalDateTime fechaActualizacion;
     private EstadoSorteo estado;
-    private Date fechaActualizacionAndroid;
 
     public BigDecimal getCantidad() {
         return cantidad;
@@ -45,11 +43,4 @@ public class Premio {
         this.estado = estado;
     }
 
-    public Date getFechaActualizacionAndroid() {
-        return fechaActualizacionAndroid;
-    }
-
-    public void setFechaActualizacionAndroid(Date fechaActualizacionAndroid) {
-        this.fechaActualizacionAndroid = fechaActualizacionAndroid;
-    }
 }

--- a/src/main/java/io/github/jcprieto/lib/loteria/model/navidad/ResumenNavidad.java
+++ b/src/main/java/io/github/jcprieto/lib/loteria/model/navidad/ResumenNavidad.java
@@ -2,13 +2,14 @@ package io.github.jcprieto.lib.loteria.model.navidad;
 
 import io.github.jcprieto.lib.loteria.enumeradores.EstadoSorteo;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.time.LocalDateTime;
-import java.util.Date;
 import java.util.List;
 
 public class ResumenNavidad implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = 4536837407643098849L;
     private String gordo;
     private String segundo;
@@ -18,7 +19,6 @@ public class ResumenNavidad implements Serializable {
     private LocalDateTime fechaActualizacion;
     private String urlPDF;
     private EstadoSorteo estado;
-    private Date fechaActualizacionAndroid;
 
     public String getGordo() {
         return gordo;
@@ -84,11 +84,4 @@ public class ResumenNavidad implements Serializable {
         this.estado = estado;
     }
 
-    public Date getFechaActualizacionAndroid() {
-        return fechaActualizacionAndroid;
-    }
-
-    public void setFechaActualizacionAndroid(Date fechaActualizacionAndroid) {
-        this.fechaActualizacionAndroid = fechaActualizacionAndroid;
-    }
 }

--- a/src/main/java/io/github/jcprieto/lib/loteria/model/nino/ResumenNino.java
+++ b/src/main/java/io/github/jcprieto/lib/loteria/model/nino/ResumenNino.java
@@ -2,13 +2,14 @@ package io.github.jcprieto.lib.loteria.model.nino;
 
 import io.github.jcprieto.lib.loteria.enumeradores.EstadoSorteo;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.time.LocalDateTime;
-import java.util.Date;
 import java.util.List;
 
 public class ResumenNino implements Serializable {
 
+    @Serial
     private static final long serialVersionUID = -8842164079641350214L;
     private String primero;
     private String segundo;
@@ -20,7 +21,6 @@ public class ResumenNino implements Serializable {
     private LocalDateTime fechaActualizacion;
     private String urlPDF;
     private EstadoSorteo estado;
-    private Date fechaActualizacionAndroid;
 
     public String getPrimero() {
         return primero;
@@ -100,13 +100,5 @@ public class ResumenNino implements Serializable {
 
     public void setEstado(EstadoSorteo estado) {
         this.estado = estado;
-    }
-
-    public Date getFechaActualizacionAndroid() {
-        return fechaActualizacionAndroid;
-    }
-
-    public void setFechaActualizacionAndroid(Date fechaActualizacionAndroid) {
-        this.fechaActualizacionAndroid = fechaActualizacionAndroid;
     }
 }

--- a/src/test/java/io/github/jcprieto/PremioConverterTest.java
+++ b/src/test/java/io/github/jcprieto/PremioConverterTest.java
@@ -45,6 +45,22 @@ public class PremioConverterTest {
     }
 
     @Test
+    public void testGetDesdeBusquedaConPremioNegativo() {
+        Busqueda busqueda = new Busqueda();
+        busqueda.setPremio(-2000);
+        busqueda.setTimestamp(0L);
+        busqueda.setStatus(0);
+
+        Premio premio = PremioConverter.get(busqueda);
+
+        Assert.assertEquals(new BigDecimal("-100"), premio.getCantidad());
+        Assert.assertEquals(EstadoSorteo.NO_INICIADO, premio.getEstado());
+        LocalDateTime esperado = LocalDateTime.ofInstant(Instant.ofEpochSecond(0L),
+                ZoneId.of("Europe/Madrid"));
+        Assert.assertEquals(esperado, premio.getFechaActualizacion());
+    }
+
+    @Test
     public void testGetDesdeSorteo() {
         Premio premio = PremioConverter.get("cerrado", "2025-12-22 08:30:00", 12000L, 200);
 
@@ -85,5 +101,14 @@ public class PremioConverterTest {
         Premio premio = PremioConverter.get("cerrado", "2025-12-22 08:30:00", 1L, 3);
 
         Assert.assertEquals(new BigDecimal("0.33333333"), premio.getCantidad());
+    }
+
+    @Test
+    public void testGetDesdeSorteoConEstadoYFechaNulos() {
+        Premio premio = PremioConverter.get(null, null, 12000L, 200);
+
+        Assert.assertEquals(new BigDecimal("60"), premio.getCantidad());
+        Assert.assertNull(premio.getEstado());
+        Assert.assertNull(premio.getFechaActualizacion());
     }
 }

--- a/src/test/java/io/github/jcprieto/SorteoResponseConverterUtilsTest.java
+++ b/src/test/java/io/github/jcprieto/SorteoResponseConverterUtilsTest.java
@@ -48,8 +48,7 @@ public class SorteoResponseConverterUtilsTest {
 
         SorteoResponseConverterUtils.setFechaActualizacionFromTimestamp(
                 timestamp,
-                local::set,
-                legacy::set
+                local::set
         );
 
         LocalDateTime esperado = LocalDateTime.ofInstant(Instant.ofEpochSecond(timestamp),
@@ -170,8 +169,7 @@ public class SorteoResponseConverterUtilsTest {
                 1700000000L,
                 ignored -> {
                     throw new NoClassDefFoundError("java.time.LocalDateTime");
-                },
-                legacy::set
+                }
         );
 
         Assert.assertNotNull(legacy.get());

--- a/src/test/java/io/github/jcprieto/SorteoResponseConverterUtilsTest.java
+++ b/src/test/java/io/github/jcprieto/SorteoResponseConverterUtilsTest.java
@@ -106,7 +106,7 @@ public class SorteoResponseConverterUtilsTest {
         AtomicReference<LocalDateTime> local = new AtomicReference<>();
         AtomicReference<java.util.Date> legacy = new AtomicReference<>();
 
-        SorteoResponseConverterUtils.setFechaActualizacion(null, local::set, legacy::set);
+        SorteoResponseConverterUtils.setFechaActualizacion(null, local::set);
 
         Assert.assertNull(local.get());
         Assert.assertNull(legacy.get());
@@ -117,7 +117,7 @@ public class SorteoResponseConverterUtilsTest {
         AtomicReference<LocalDateTime> local = new AtomicReference<>();
         AtomicReference<java.util.Date> legacy = new AtomicReference<>();
 
-        SorteoResponseConverterUtils.setFechaActualizacion("2025-12-22 08:30:00", local::set, legacy::set);
+        SorteoResponseConverterUtils.setFechaActualizacion("2025-12-22 08:30:00", local::set);
 
         Assert.assertEquals(LocalDateTime.of(2025, 12, 22, 8, 30, 0), local.get());
         Assert.assertNull(legacy.get());
@@ -128,7 +128,7 @@ public class SorteoResponseConverterUtilsTest {
         AtomicReference<LocalDateTime> local = new AtomicReference<>();
         AtomicReference<java.util.Date> legacy = new AtomicReference<>();
 
-        SorteoResponseConverterUtils.setFechaActualizacion("2025/12/22", local::set, legacy::set);
+        SorteoResponseConverterUtils.setFechaActualizacion("2025/12/22", local::set);
 
         Assert.assertNull(local.get());
         Assert.assertNull(legacy.get());
@@ -142,8 +142,7 @@ public class SorteoResponseConverterUtilsTest {
                 "2025-12-22 08:30:00",
                 ignored -> {
                     throw new NoClassDefFoundError("java.time.LocalDateTime");
-                },
-                legacy::set
+                }
         );
 
         Assert.assertNotNull(legacy.get());
@@ -157,8 +156,7 @@ public class SorteoResponseConverterUtilsTest {
                 "22/12/2025",
                 ignored -> {
                     throw new NoClassDefFoundError("java.time.LocalDateTime");
-                },
-                legacy::set
+                }
         );
 
         Assert.assertNull(legacy.get());

--- a/src/test/java/io/github/jcprieto/SorteoResponseConverterUtilsTest.java
+++ b/src/test/java/io/github/jcprieto/SorteoResponseConverterUtilsTest.java
@@ -43,7 +43,6 @@ public class SorteoResponseConverterUtilsTest {
     @Test
     public void testSetFechaActualizacionFromTimestamp() {
         AtomicReference<LocalDateTime> local = new AtomicReference<>();
-        AtomicReference<java.util.Date> legacy = new AtomicReference<>();
         long timestamp = 1700000000L;
 
         SorteoResponseConverterUtils.setFechaActualizacionFromTimestamp(
@@ -54,7 +53,6 @@ public class SorteoResponseConverterUtilsTest {
         LocalDateTime esperado = LocalDateTime.ofInstant(Instant.ofEpochSecond(timestamp),
                 ZoneId.of("Europe/Madrid"));
         Assert.assertEquals(esperado, local.get());
-        Assert.assertNull(legacy.get());
     }
 
     @Test
@@ -103,76 +101,28 @@ public class SorteoResponseConverterUtilsTest {
     @Test
     public void testSetFechaActualizacionConFechaNulaNoHaceNada() {
         AtomicReference<LocalDateTime> local = new AtomicReference<>();
-        AtomicReference<java.util.Date> legacy = new AtomicReference<>();
 
         SorteoResponseConverterUtils.setFechaActualizacion(null, local::set);
 
         Assert.assertNull(local.get());
-        Assert.assertNull(legacy.get());
     }
 
     @Test
     public void testSetFechaActualizacionConFormatoValidoSeteaLocalDateTime() {
         AtomicReference<LocalDateTime> local = new AtomicReference<>();
-        AtomicReference<java.util.Date> legacy = new AtomicReference<>();
 
         SorteoResponseConverterUtils.setFechaActualizacion("2025-12-22 08:30:00", local::set);
 
         Assert.assertEquals(LocalDateTime.of(2025, 12, 22, 8, 30, 0), local.get());
-        Assert.assertNull(legacy.get());
     }
 
     @Test
     public void testSetFechaActualizacionConFormatoInvalidoNoSeteaCampos() {
         AtomicReference<LocalDateTime> local = new AtomicReference<>();
-        AtomicReference<java.util.Date> legacy = new AtomicReference<>();
 
         SorteoResponseConverterUtils.setFechaActualizacion("2025/12/22", local::set);
 
         Assert.assertNull(local.get());
-        Assert.assertNull(legacy.get());
-    }
-
-    @Test
-    public void testSetFechaActualizacionConFallbackLegacyCuandoFallaLocalDateTime() {
-        AtomicReference<java.util.Date> legacy = new AtomicReference<>();
-
-        SorteoResponseConverterUtils.setFechaActualizacion(
-                "2025-12-22 08:30:00",
-                ignored -> {
-                    throw new NoClassDefFoundError("java.time.LocalDateTime");
-                }
-        );
-
-        Assert.assertNotNull(legacy.get());
-    }
-
-    @Test
-    public void testSetFechaActualizacionConFallbackLegacyYFormatoInvalido() {
-        AtomicReference<java.util.Date> legacy = new AtomicReference<>();
-
-        SorteoResponseConverterUtils.setFechaActualizacion(
-                "22/12/2025",
-                ignored -> {
-                    throw new NoClassDefFoundError("java.time.LocalDateTime");
-                }
-        );
-
-        Assert.assertNull(legacy.get());
-    }
-
-    @Test
-    public void testSetFechaActualizacionFromTimestampFallbackLegacyCuandoFallaLocalDateTime() {
-        AtomicReference<java.util.Date> legacy = new AtomicReference<>();
-
-        SorteoResponseConverterUtils.setFechaActualizacionFromTimestamp(
-                1700000000L,
-                ignored -> {
-                    throw new NoClassDefFoundError("java.time.LocalDateTime");
-                }
-        );
-
-        Assert.assertNotNull(legacy.get());
     }
 
     private SorteoNavidadResponse.PremioDetalle premio(String decimo) {


### PR DESCRIPTION
## 7.0.0

- Cambio rompedor: se elimina el soporte legacy de fechas de actualizacion basadas en `java.util.Date` para Android.
  Las fechas de actualizacion se exponen y calculan unicamente como `LocalDateTime`.
- Eliminados los accesores `getFechaActualizacionAndroid()` y `setFechaActualizacionAndroid(...)` de `Premio`,
  `ResumenNavidad` y `ResumenNino`.
- Simplificados los convertidores de premios y resumenes para usar directamente `LocalDateTime`, eliminando el fallback
  interno que capturaba `NoClassDefFoundError`.
- Cambio rompedor en `SorteoResponseConverterUtils`: los metodos de fecha ya no reciben `Consumer<Date>` y solo aceptan
  el setter de `LocalDateTime`.
- Actualizacion de mantenimiento: `jackson-databind` de `2.22.0` a `2.22.1`.
- Ampliacion y ajuste de tests unitarios de `PremioConverter` y `SorteoResponseConverterUtils` para reflejar el nuevo
  contrato sin fallback legacy.